### PR TITLE
Set upper limit for the cclib version.

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -37,7 +37,7 @@
     "install_requires": [
         "aiida-core>=1.0.0,<2.0.0",
         "pymatgen>=2020.4,<2022.0.0",
-        "cclib>=1.6.1",
+        "cclib>=1.6.1,<=1.7",
         "ase"
     ],
     "extras_require": {


### PR DESCRIPTION
In version 1.7.1 cclib gaussian parser stores execution time in
`datetime.timedelta` format. Unfortunately, AiiDA can't store it
in the `Dict` object. As a temporary fix, we set the upper limit for
the `cclib` to 1.7.