### PR TITLE
Update dependencies; make compatible with python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
                     - 5672:5672
         strategy:
             matrix:
-                python-version: [3.8]
+                python-version: ['3.8', '3.9', '3.10', '3.11']
         steps:
             - uses: actions/checkout@v2
 

--- a/aiida_gaussian/parsers/gaussian.py
+++ b/aiida_gaussian/parsers/gaussian.py
@@ -222,7 +222,7 @@ class GaussianAdvancedParser(GaussianBaseParser):
             mo_e = np.array(property_dict["moenergies"])
 
             # if either HOMO is negative, such as in the case of H, don't extract gap
-            if any([h < 0 for h in property_dict["homos"]]):
+            if any(h < 0 for h in property_dict["homos"]):
                 return
             try:
                 if nspin == 1:

--- a/aiida_gaussian/tests/parsers/test_base/test_nan_inf.yml
+++ b/aiida_gaussian/tests/parsers/test_base/test_nan_inf.yml
@@ -14,6 +14,8 @@ geovalues:
   - 0.000226
 metadata:
   basis_set: def2SVP
+  cpu_time:
+  - 1127102.5
   functional: M062X
   legacy_package_version: 16revisionC.02
   methods:
@@ -22,6 +24,10 @@ metadata:
   package_version: 2016+C.02
   platform: ES64L
   success: true
+  symmetry_detected: c1
+  symmetry_used: c1
+  wall_time:
+  - 27721.6
 moments:
 - - 0.0
   - 0.0
@@ -69,6 +75,10 @@ num_electrons:
 optdone: true
 optstatus:
 - 5
+rotconsts:
+- - 0.0476335
+  - 0.0342489
+  - 0.0246577
 scfenergies:
 - -101066.91992696088
 scftargets:

--- a/examples/example_cubes_workchain.py
+++ b/examples/example_cubes_workchain.py
@@ -93,7 +93,7 @@ def example(gaussian_code, formchk_code, cubegen_code):
             filename = f"./{aname}_h{h:.1f}.png"
             plt.savefig(filename, dpi=200, bbox_inches="tight")
             plt.close()
-            print("Saved %s!" % filename)
+            print(f"Saved {filename}!")
 
 
 @click.command("cli")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.7"
 dependencies = [
     "aiida-core>=2.0.0,<3.0.0",
     "pymatgen>=2022.1.20",
-    "cclib>=1.6.1,<=1.7",
+    "cclib>=1.8,<=2.0",
     "ase",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 requires-python = ">=3.7"
 dependencies = [
     "aiida-core>=2.0.0,<3.0.0",
-    "pymatgen>=2022.1.20,<2023.0.0",
+    "pymatgen>=2022.1.20",
     "cclib>=1.6.1,<=1.7",
     "ase",
 ]


### PR DESCRIPTION
Added build & tests for more python versions: 3.8, 3.9, 3.10, 3.11. Before it only tested 3.8.

Python 3.11 was not compatible with cclib<=1.7, so i updated that as well. In 1.8 they introduced `datetime.timedelta` types in the parsed dictionary, which is not serializable to AiiDA nodes, so i convert it to a float of seconds.

